### PR TITLE
Remove postinstall script in package.json

### DIFF
--- a/karma.conf.js
+++ b/karma.conf.js
@@ -14,9 +14,9 @@ module.exports = function(config) {
 
     // list of files / patterns to load in the browser
     files: [
-      'bower_components/jquery/jquery.js',
-	  'bower_components/angular/angular.js',
-      'bower_components/angular-mocks/angular-mocks.js',
+      '+(bower_components|node_modules)/jquery/?(dist)/jquery.js',
+      '+(bower_components|node_modules)/angular/angular.js',
+      '+(bower_components|node_modules)/angular-mocks/angular-mocks.js',
       'src/**/*.js'
     ],
 

--- a/package.json
+++ b/package.json
@@ -8,7 +8,6 @@
     "angular-idle.map"
   ],
   "scripts": {
-    "postinstall": "node_modules/.bin/bower install",
     "test": "grunt test"
   },
   "repository": {
@@ -21,7 +20,6 @@
     "url": "https://github.com/HackedByChinese/ng-idle/issues"
   },
   "devDependencies": {
-    "bower": "^1.3.9",
     "grunt": "~0.4.2",
     "grunt-bump": "0.0.13",
     "grunt-contrib-clean": "~0.5.0",
@@ -40,6 +38,9 @@
     "karma-requirejs": "~0.2.1",
     "karma-script-launcher": "~0.1.0",
     "matchdep": "~0.3.0",
-    "requirejs": "~2.1.10"
+    "requirejs": "~2.1.10",
+    "angular": "~1.3.15",
+    "angular-mocks": "~1.3.15",
+    "jquery": "~2.1.3"
   }
 }


### PR DESCRIPTION
The "postinstall" script in package.json runs "bower install" making bower mandatory when installing as node module.

This patch removes this line and replaces it by a npm only solution:
- Anguar, angular-mocks and jquery as devDeps in package.json
- Changed "files" entry in karma.conf.js from "bower_components/..." to "+(bower_components|node_modules)/.."