### PR TITLE
Align package.json dependencies versions with bower.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -39,8 +39,8 @@
     "karma-script-launcher": "~0.1.0",
     "matchdep": "~0.3.0",
     "requirejs": "~2.1.10",
-    "angular": "~1.3.15",
-    "angular-mocks": "~1.3.15",
-    "jquery": "~2.1.3"
+    "angular": "^1.2.0",
+    "angular-mocks": "^1.2.0",
+    "jquery": "^2.0.3"
   }
 }


### PR DESCRIPTION
Versions of angular, angular-mocks and jquery should be the same in bower.json and package.json

Sorry I forgot this in my previous commit!