### PR TITLE
Fixed package.json so there's only one entry point

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,11 +12,7 @@
     "user",
     "session"
   ],
-  "main": [
-    "angular-idle.js",
-    "angular-idle.min.js",
-    "angular-idle.map"
-  ],
+  "main": "angular-idle.js",
   "scripts": {
     "test": "grunt test"
   },


### PR DESCRIPTION
You can't `require('ng-idle')` (using browserify) if there's more than one entry point, and it fails with:

```
path.js:313
        throw new TypeError('Arguments to path.resolve must be strings');
        ^
TypeError: Arguments to path.resolve must be strings
    at Object.exports.resolve (path.js:313:15)
    at /Users/briggs/Repositories/Bluestream/frontend/node_modules/gulp-browserify/node_modules/browserify/node_modules/resolve/lib/async.js:91:37
    at fs.js:271:14
    at Object.oncomplete (fs.js:107:15)
```

[More info on the main parameter](http://stackoverflow.com/questions/22512992/node-js-package-json-main-parameter).

Ping @HackedByChinese (AKA Lo Pan)