### PR TITLE
Attach event listener to html instead of body

### DIFF
--- a/angular-idle.js
+++ b/angular-idle.js
@@ -286,7 +286,7 @@ angular.module('ngIdle.idle', ['ngIdle.keepalive', 'ngIdle.localStorage'])
           }
         };
 
-        $document.find('body').on(options.interrupt, function() {
+        $document.find('html').on(options.interrupt, function() {
           svc.interrupt();
         });
 


### PR DESCRIPTION
In some Angular applications, a user might make changes to the document body that result in ngIdle's event listener getting removed. In order to minimize the chances of this happening, the ng-idle event listener should be attached to the highest level tag in the document (html). 

We had a case at work where logging in/out of the Angular application would replace the document body but not cause a full page refresh. Needless to say this caused a few headaches when ngIdle's event listener got removed, causing users to get logged out of our application for inactivity even if they were being active on the page.