### PR TITLE
Late IdleWarn event with multiple tabs open

### DIFF
--- a/src/idle/idle.js
+++ b/src/idle/idle.js
@@ -85,6 +85,13 @@ angular.module('ngIdle.idle', ['ngIdle.keepalive', 'ngIdle.localStorage'])
         }
 
         function countdown() {
+
+          // check not called when no longer idling
+          // possible with multiple tabs
+          if(!state.idling){
+            return;  
+          }
+
           // countdown has expired, so signal timeout
           if (state.countdown <= 0) {
             timeout();


### PR DESCRIPTION
With multiple tabs open a interval function can be called when the state is no longer idle. I have added a simple check to ensure we do not broadcast another 'IdleWarn' event.