### PR TITLE
Adds a way to specify window level interrupts

### DIFF
--- a/src/idle/idle.js
+++ b/src/idle/idle.js
@@ -5,6 +5,7 @@ angular.module('ngIdle.idle', ['ngIdle.keepalive', 'ngIdle.localStorage'])
       timeout: 30, // in seconds (default is 30sec)
       autoResume: 'idle', // lets events automatically resume (unsets idle state/resets warning)
       interrupt: 'mousemove keydown DOMMouseScroll mousewheel mousedown touchstart touchmove scroll',
+      windowInterrupt: null,
       keepalive: true
     };
 
@@ -20,6 +21,10 @@ angular.module('ngIdle.idle', ['ngIdle.keepalive', 'ngIdle.localStorage'])
 
     this.interrupt = function(events) {
       options.interrupt = events;
+    };
+
+    this.windowInterrupt = function(events) {
+      options.windowInterrupt = events;
     };
 
     var setIdle = this.idle = function(seconds) {
@@ -221,6 +226,16 @@ angular.module('ngIdle.idle', ['ngIdle.keepalive', 'ngIdle.localStorage'])
             svc.interrupt();
           }
         });
+
+        if(options.windowInterrupt) {
+          var eventList = options.windowInterrupt.split(' ');
+
+          for(var i=0; i<eventList.length; i++) {
+            $window.addEventListener(eventList[i], function() {
+              svc.interrupt();
+            });
+          }
+        }
 
         var wrap = function(event) {
           if (event.key === 'ngIdle.expiry' && event.newValue && event.newValue !== event.oldValue) {

--- a/src/idle/idle.spec.js
+++ b/src/idle/idle.spec.js
@@ -61,6 +61,14 @@ describe('ngIdle', function() {
         expect(create()._options().interrupt).toBe('click');
       });
 
+      it('windowInterrupt() should update defaults', function() {
+        expect(IdleProvider).not.toBeUndefined();
+
+        IdleProvider.windowInterrupt('focus');
+
+        expect(create()._options().windowInterrupt).toBe('focus');
+      });
+
       it('idle() should update defaults', function() {
         expect(IdleProvider).not.toBeUndefined();
 
@@ -400,6 +408,16 @@ describe('ngIdle', function() {
 
       //   expect(Idle.idling()).toBe(false);
       // });
+
+
+      //HACK: this has the same issues as the test above
+      //it('window event should interrupt idle timeout', function() {
+      //  IdleProvider.windowInterrupt('focus');
+      //  Idle = create();
+      //
+      //  Idle.watch();
+      //
+      //});
     });
 
     describe('Idle with different autoResume values', function() {


### PR DESCRIPTION
Use Case:
Firing interrupt() when leaving a browser/tab (window 'blur' event) and returning to the browser/tab (window 'focus' event) without having to interact with the page further.

Practical Use Case:
When using a mobile device and you want to immediately log a user out if they're returning to the page after the timeout has ended (ie locking the device or switching apps)

Interesting Thing of Note:
Chrome for ios does not fire window 'focus' or 'blur' events when the app is opened or put in the background, but it does fire them when the tabs are opened or put in the background.