### PR TITLE
export 'ngIdle' so it can be used as a node module

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,2 @@
+require('./angular-idle');
+module.exports = 'ngIdle';

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
     "user",
     "session"
   ],
-  "main": "angular-idle.js",
+  "main": "index.js",
   "scripts": {
     "test": "grunt test"
   },


### PR DESCRIPTION
The pattern in angular is for the module to export the name of the module (for instance, angular-aria, angular-material, angular-animate)