### PR TITLE
Re-add missing index.js

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,0 +1,2 @@
+require('./angular-idle');
+module.exports = 'ngIdle';


### PR DESCRIPTION
index.js is the "main" file as defined in the package.json and needs to
be present. The package.json currently points to a non-existent file.
It was added by 205370c11dcfc77827ce632c001f0d4b70c1aa0d so that ngIdle
could be used as a node import